### PR TITLE
Remove `apt` package resource without version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,12 +6,6 @@
     update_cache: true
   notify: Start Redis
 
-- name: Install php-redis
-  apt:
-    pkg: php-redis
-    state: present
-    update_cache: true
-
 - name: Install php{{ php_version }}-redis
   apt:
     pkg: php{{ php_version }}-redis


### PR DESCRIPTION
This PR removes the `apt` package resource without explicit version, 
as this can cause unnecessary PHP extension packages being installed.


@jhcloos: You were watching my fork, I am now using this well-maintained fork 
(deleted mine as it was based of an unmaintained fork) and want to recommend it to you.